### PR TITLE
Grab status code from response with only one HTTP version number

### DIFF
--- a/src/Facebook/Http/GraphRawResponse.php
+++ b/src/Facebook/Http/GraphRawResponse.php
@@ -105,6 +105,13 @@ class GraphRawResponse
     public function setHttpResponseCodeFromHeader($rawResponseHeader)
     {
         preg_match('|HTTP/\d\.\d\s+(\d+)\s+.*|', $rawResponseHeader, $match);
+        
+        if (isset($match[1])) {
+            $this->httpResponseCode = (int)$match[1];
+        }
+
+        preg_match('|HTTP/\d\s+(\d+)\s+.*|', $rawResponseHeader, $match);
+        
         $this->httpResponseCode = (int)$match[1];
     }
 

--- a/tests/Http/GraphRawResponseTest.php
+++ b/tests/Http/GraphRawResponseTest.php
@@ -47,6 +47,24 @@ HEADER;
         'X-FB-Debug' => '02QQiffE7JG2rV6i/Agzd0gI2/OOQ2lk5UW0=',
         'Access-Control-Allow-Origin' => '*',
     ];
+    
+    protected $fakeRawHeaderVersion2 = <<<HEADER
+HTTP/2 200 OK
+Etag: "9d86b21aa74d74e574bbb35ba13524a52deb96e5"
+Content-Type: text/javascript; charset=UTF-8
+X-FB-Rev: 9244769
+Date: Mon, 5 December 2022 18:37:17 GMT
+X-FB-Debug: 02QQiffE7JG2rV6i/Agzd0gI2/OOQ2lk5UW0=
+Access-Control-Allow-Origin: *\r\n\r\n
+HEADER;
+    protected $fakeHeadersAsArrayVersion2 = [
+        'Etag' => '"9d86b21aa74d74e574bbb35ba13524a52deb96e5"',
+        'Content-Type' => 'text/javascript; charset=UTF-8',
+        'X-FB-Rev' => '9244769',
+        'Date' => 'Mon, 5 December 2022 18:37:17 GMT',
+        'X-FB-Debug' => '02QQiffE7JG2rV6i/Agzd0gI2/OOQ2lk5UW0=',
+        'Access-Control-Allow-Origin' => '*',
+    ];
 
     public function testCanSetTheHeadersFromAnArray()
     {
@@ -77,6 +95,16 @@ HEADER;
         $httpResponseCode = $response->getHttpResponseCode();
 
         $this->assertEquals($this->fakeHeadersAsArray, $headers);
+        $this->assertEquals(200, $httpResponseCode);
+    }
+    
+    public function testCanSetTheHeadersFromAStringWithVersionTwo()
+    {
+        $response = new GraphRawResponse($this->$fakeRawHeaderVersion2, '');
+        $headers = $response->getHeaders();
+        $httpResponseCode = $response->getHttpResponseCode();
+
+        $this->assertEquals($this->fakeHeadersAsArrayVersion2, $headers);
         $this->assertEquals(200, $httpResponseCode);
     }
 }

--- a/tests/Http/GraphRawResponseTest.php
+++ b/tests/Http/GraphRawResponseTest.php
@@ -100,7 +100,7 @@ HEADER;
     
     public function testCanSetTheHeadersFromAStringWithVersionTwo()
     {
-        $response = new GraphRawResponse($this->$fakeRawHeaderVersion2, '');
+        $response = new GraphRawResponse($this->fakeRawHeaderVersion2, '');
         $headers = $response->getHeaders();
         $httpResponseCode = $response->getHttpResponseCode();
 


### PR DESCRIPTION
Currently, the regex is looking for HTTP version formats with major and minor versions.
```
HTTP/1.1 200 OK
```

This adds functionality to also grab status codes with only a major HTTP version like below
```
HTTP/2 200
```

Currently if you get a response with an HTTP version number with a single number the code throws an error.